### PR TITLE
fix: add path option to server socket client initialization

### DIFF
--- a/pages/api/socketio.ts
+++ b/pages/api/socketio.ts
@@ -29,7 +29,7 @@ import { Server } from "socket.io";
 
 const socketioHandler = (req: any, res: any) => {
   if (!res.socket.server.io) {
-    const io = new Server(res.socket.server);
+    const io = new Server(res.socket.server, { path: "/api/socketio" });
 
     io.on("connection", (socket) => {
       console.log("User connected succesfully");


### PR DESCRIPTION
# 문제 요약
## Socket io 이슈
- Socket io Server 는 path option 을 주지 않을 경우 기본값이 `/socket.io` 입니다. [문서](https://socket.io/docs/v4/server-options/#path)
- socket 에 대한 next api path 는 `domain/api/socketio` 입니다.
- socket 서버에 별도의 path 를 부여하지 않았으므로 다음과 같이 됩니다.
  - socketio nextjs api routes: `HTTP /api/socketio`
  - socketio ws routes: `WS /socketio`
- 클라이언트 socketio 는 `WS /api/socketio` 로 요청을 보냅니다.
- 이 path 가 서로 맞지 않기 때문에 (`/api/socketio` vs `/socketio`) Socket 서버가 커넥션을 잡아내지 못합니다.
  - 그래서 로컬 환경에서 클라이언트 쪽 path 를 `/socketio`로 하면 성공하는 것입니다. 실제로 `/socketio` 라는 경로는 next.js api 상으로는 존재하지 않지만, socketio 프로세스가 해당 ws 네트워크 요청을 확인하고 커넥션을 맺기 때문입니다. 